### PR TITLE
feat: highlight active saved query with visual feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,11 +23,11 @@ function App() {
 
   const getHistory = async (query = "") => {
     setIsLoading(true);
-    setSearchQuery(query);
+    setSearchQuery(query.trim());
     try {
       await initializeStorage();
       const results: HistoryItem[] = query.trim()
-        ? await search(query)
+        ? await search(query.trim())
         : await getRecentHistories(3);
       setHistory(results);
     } catch (error) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,7 @@ interface HeaderProps {
   savedQueries: SavedQuery[];
   onSavedQueryRemove: (id: string) => void;
   isLoading: boolean;
+  currentQuery?: string;
 }
 
 export const Header: FC<HeaderProps> = memo(function Header({
@@ -19,6 +20,7 @@ export const Header: FC<HeaderProps> = memo(function Header({
   savedQueries,
   onSavedQueryRemove,
   isLoading,
+  currentQuery,
 }) {
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -40,6 +42,7 @@ export const Header: FC<HeaderProps> = memo(function Header({
         queries={savedQueries}
         onQueryClick={handleSavedQueryClick}
         onQueryRemove={onSavedQueryRemove}
+        currentQuery={currentQuery}
       />
     </header>
   );

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -35,6 +35,7 @@ export const Root: FC<RootProps> = ({
         savedQueries={savedQueries}
         onSavedQueryRemove={onSavedQueryRemove}
         isLoading={isLoading}
+        currentQuery={searchQuery}
       />
       <Histories
         history={history}

--- a/src/components/SavedQueries.module.css
+++ b/src/components/SavedQueries.module.css
@@ -17,6 +17,10 @@
   backdrop-filter: blur(10px);
 }
 
+.savedQuery--active {
+  background: rgba(255, 255, 255, 0.3);
+}
+
 .savedQuery:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
@@ -37,6 +41,10 @@
   max-width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.savedQuery--active > .queryButton {
+  font-weight: 600;
 }
 
 .removeButton {

--- a/src/components/SavedQueries.stories.tsx
+++ b/src/components/SavedQueries.stories.tsx
@@ -69,3 +69,14 @@ export const Empty: Story = {
     queries: [],
   },
 };
+
+export const WithActiveQuery: Story = {
+  args: {
+    queries: [
+      { id: "1", query: "react", createdAt: Date.now() - 1000 },
+      { id: "2", query: "typescript", createdAt: Date.now() - 2000 },
+      { id: "3", query: "storybook", createdAt: Date.now() - 3000 },
+    ],
+    currentQuery: "typescript",
+  },
+};

--- a/src/components/SavedQueries.tsx
+++ b/src/components/SavedQueries.tsx
@@ -9,6 +9,7 @@ interface SavedQueriesProps {
   onQueryClick: (query: string) => void;
   onQueryRemove: (id: string) => void;
   className?: string;
+  currentQuery?: string;
 }
 
 export const SavedQueries: FC<SavedQueriesProps> = ({
@@ -16,6 +17,7 @@ export const SavedQueries: FC<SavedQueriesProps> = ({
   onQueryClick,
   onQueryRemove,
   className,
+  currentQuery,
 }) => {
   if (queries.length === 0) {
     return null;
@@ -24,7 +26,13 @@ export const SavedQueries: FC<SavedQueriesProps> = ({
   return (
     <div className={classNames(className, styles.savedQueries)}>
       {queries.map((savedQuery) => (
-        <div key={savedQuery.id} className={styles.savedQuery}>
+        <div
+          key={savedQuery.id}
+          className={classNames(
+            styles.savedQuery,
+            currentQuery === savedQuery.query && styles["savedQuery--active"],
+          )}
+        >
           <button
             type='button'
             onClick={() => onQueryClick(savedQuery.query)}


### PR DESCRIPTION
## Summary

- SavedQueriesコンポーネントに現在のクエリをハイライト表示する機能を追加
- アクティブなクエリボタンに視覚的フィードバックを提供
- Storybookストーリーでアクティブ状態のテストが可能

## Changes

- `SavedQueries`コンポーネントに`currentQuery` propを追加
- アクティブなクエリに対応するボタンの背景色を変更し、フォントウェイトを太字に
- App、Header、Rootコンポーネントでの統合を更新
- 検索クエリのtrim処理でホワイトスペースマッチング問題を修正

## Test plan

- [x] Storybookで`WithActiveQuery`ストーリーを確認
- [x] アクティブなクエリボタンの視覚的フィードバックを確認
- [x] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)