### PR TITLE
feat: add release body input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release Extension
 
 on:
   workflow_dispatch:
+    inputs:
+      release_body:
+        description: "Release body (changelog)"
+        required: true
+        type: string
 
 jobs:
   build-and-release:
@@ -56,7 +61,8 @@ jobs:
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v2
         with:
-          files: output/eternal-history-v${{ env.VERSION }}.zip        
+          files: output/eternal-history-v${{ env.VERSION }}.zip
           tag_name: v${{ env.VERSION }}
+          body: ${{ github.event.inputs.release_body }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- リリースワークフロー実行時にリリース本文（changelog）を入力できるように改善
- GitHub Releaseに入力されたリリース本文が設定されるように修正

## Changes

- `workflow_dispatch`に`release_body`入力パラメータを追加
- リリース作成時に入力されたリリース本文を`body`として設定
- リリース本文は必須入力として設定

## Test plan

- [ ] ワークフローを手動実行してリリース本文入力フィールドが表示されることを確認
- [ ] 入力したリリース本文がGitHub Releaseに正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)