### PR TITLE
feat: add site: domain search syntax with performance optimization

### DIFF
--- a/src/components/HistoryItem.tsx
+++ b/src/components/HistoryItem.tsx
@@ -14,8 +14,12 @@ interface HistoryItemProps {
 }
 
 // テキストハイライト用の関数
-const renderHighlightedText = (text: string, searchQuery: string) => {
-  const highlighted = highlightText(text, searchQuery);
+const renderHighlightedText = (
+  text: string,
+  searchQuery: string,
+  type: "url" | "title",
+) => {
+  const highlighted = highlightText(text, searchQuery, type);
   return highlighted.map((part, index) => {
     if (part.highlight) {
       return (
@@ -67,10 +71,10 @@ export const HistoryItem: FC<HistoryItemProps> = memo(function HistoryItem({
       <img src={favicon} className={styles.icon} />
       <div className={styles.linkContainer}>
         <span className={styles.title} title={item.title || item.url}>
-          {renderHighlightedText(item.title || item.url, searchQuery)}
+          {renderHighlightedText(item.title || item.url, searchQuery, "title")}
         </span>
         <span className={styles.url} title={item.url}>
-          {renderHighlightedText(item.url, searchQuery)}
+          {renderHighlightedText(item.url, searchQuery, "url")}
         </span>
       </div>
 

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,3 +1,5 @@
+import { ParsedSearchQuery, parseSearchQuery } from "./query";
+
 /**
  * テキスト内の検索クエリにマッチする部分をハイライト用のJSX要素に変換する
  * @param text - ハイライト対象のテキスト
@@ -7,31 +9,31 @@
 export const highlightText = (
   text: string,
   query: string,
+  type: "url" | "title",
 ): { highlight: boolean; content: string }[] => {
   // クエリが空の場合はそのままテキストを返す
   if (!query.trim()) {
     return [{ highlight: false, content: text }];
   }
 
-  // クエリを単語に分割し、空文字を除去
-  const queryWords = query
-    .trim()
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((word) => word.length > 0);
-
-  if (queryWords.length === 0) {
+  const parsedQuery = parseSearchQuery(query).filter((q) => {
+    if (q.type === "site") {
+      return type === "url";
+    }
+    return true;
+  });
+  if (parsedQuery.length === 0) {
     return [{ highlight: false, content: text }];
   }
 
   // 正規表現用にエスケープする関数
-  const escapeRegExp = (string: string): string => {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapeTermRegExp = (query: ParsedSearchQuery): string => {
+    return query.term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   };
 
   // 全ての検索単語を含む正規表現を作成（大文字小文字を区別しない）
   const pattern = new RegExp(
-    `(${queryWords.map(escapeRegExp).join("|")})`,
+    `(${parsedQuery.map(escapeTermRegExp).join("|")})`,
     "gi",
   );
 
@@ -40,7 +42,7 @@ export const highlightText = (
     .split(pattern)
     .map((part) => {
       return {
-        highlight: queryWords.some((w) => part.toLowerCase() === w),
+        highlight: parsedQuery.some((w) => part.toLowerCase() === w.term),
         content: part,
       };
     })
@@ -52,17 +54,17 @@ if (import.meta.vitest) {
 
   describe("highlightText", () => {
     it("should return original text when query is empty", () => {
-      const result = highlightText("Hello world", "");
+      const result = highlightText("Hello world", "", "title");
       expect(result).toEqual([{ content: "Hello world", highlight: false }]);
     });
 
     it("should return original text when query is only whitespace", () => {
-      const result = highlightText("Hello world", "   ");
+      const result = highlightText("Hello world", "   ", "title");
       expect(result).toEqual([{ content: "Hello world", highlight: false }]);
     });
 
     it("should highlight single word match", () => {
-      const result = highlightText("Hello world", "hello");
+      const result = highlightText("Hello world", "hello", "title");
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual({
         highlight: true,
@@ -75,7 +77,11 @@ if (import.meta.vitest) {
     });
 
     it("should highlight multiple word matches", () => {
-      const result = highlightText("Hello beautiful world", "hello world");
+      const result = highlightText(
+        "Hello beautiful world",
+        "hello world",
+        "title",
+      );
       expect(result).toHaveLength(3);
       expect(result[0]).toEqual({
         highlight: true,
@@ -88,7 +94,7 @@ if (import.meta.vitest) {
     });
 
     it("should handle case insensitive matching", () => {
-      const result = highlightText("GitHub Repository", "githuB rePo");
+      const result = highlightText("GitHub Repository", "githuB rePo", "title");
       expect(result).toHaveLength(4);
       expect(result[0]).toEqual({
         highlight: true,
@@ -101,7 +107,7 @@ if (import.meta.vitest) {
     });
 
     it("should handle partial word matches", () => {
-      const result = highlightText("JavaScript programming", "script");
+      const result = highlightText("JavaScript programming", "script", "title");
       expect(result).toHaveLength(3);
       expect(result[1]).toEqual({
         highlight: true,
@@ -110,7 +116,7 @@ if (import.meta.vitest) {
     });
 
     it("should handle special regex characters in query", () => {
-      const result = highlightText("test@example.com", "@example");
+      const result = highlightText("test@example.com", "@example", "title");
       expect(result).toHaveLength(3);
       expect(result[1]).toEqual({
         highlight: true,
@@ -119,14 +125,37 @@ if (import.meta.vitest) {
     });
 
     it("should handle no matches", () => {
-      const result = highlightText("Hello world", "xyz");
+      const result = highlightText("Hello world", "xyz", "title");
       expect(result).toEqual([{ content: "Hello world", highlight: false }]);
     });
 
     it("should handle multiple occurrences of same word", () => {
-      const result = highlightText("test test test", "test");
+      const result = highlightText("test test test", "test", "title");
       expect(result).toHaveLength(5);
       expect(result.filter((part) => part.highlight)).toHaveLength(3);
+    });
+
+    it("should handle site: queries", () => {
+      const result = highlightText(
+        "Visit example.com for more info",
+        "site:example.com",
+        "url",
+      );
+      expect(result).toHaveLength(3);
+      expect(result[1]).toEqual({
+        highlight: true,
+        content: "example.com",
+      });
+    });
+
+    it("should not highlight site: queries in title", () => {
+      const result = highlightText(
+        "Visit example.com for more info",
+        "site:example.com",
+        "title",
+      );
+      expect(result).toHaveLength(1);
+      expect(result.filter((part) => part.highlight)).toHaveLength(0);
     });
   });
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,0 +1,31 @@
+export type ParsedSearchQuery = {
+  term: string;
+  type: "text" | "site";
+};
+
+/**
+ * 検索クエリを解析して各タームの種類を識別します。
+ */
+export function parseSearchQuery(query: string): Array<ParsedSearchQuery> {
+  const terms = query
+    .trim()
+    .split(/\s+/)
+    .filter((term) => term.length > 0);
+
+  const parsedTerms = terms
+    .map((term) => {
+      if (term.toLowerCase().startsWith("site:")) {
+        const siteTerm = term.slice(5).toLowerCase();
+        if (siteTerm.length > 0) {
+          return { term: siteTerm, type: "site" } as const;
+        }
+        return null;
+      }
+      return { term: term.toLowerCase(), type: "text" } as const;
+    })
+    .filter((item) => item !== null)
+    // テキスト検索語を長い順にソート (最も長い単語でまず検索するため)
+    .sort((a, b) => b.term.length - a.term.length);
+
+  return parsedTerms;
+}

--- a/src/lib/storage.spec.ts
+++ b/src/lib/storage.spec.ts
@@ -419,6 +419,158 @@ describe("storage", () => {
       // Should not find the bookmark outside root folder
       expect(resultOutside).toEqual([]);
     });
+
+    it("should search by site: syntax for domain matching", async () => {
+      // Create test bookmarks with different domains
+      const historyItems: HistoryItem[] = [
+        {
+          id: "1",
+          url: "https://google.com/search",
+          title: "Google Search",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 10, 30, 0).getTime(),
+          domain: "google.com",
+        },
+        {
+          id: "2",
+          url: "https://maps.google.com",
+          title: "Google Maps",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 11, 0, 0).getTime(),
+          domain: "maps.google.com",
+        },
+        {
+          id: "3",
+          url: "https://yahoo.com",
+          title: "Yahoo Homepage",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 12, 0, 0).getTime(),
+          domain: "yahoo.com",
+        },
+      ];
+      await insertHistories(...historyItems);
+
+      // Test exact domain search
+      const googleResult = await search("site:google.com");
+      expect(googleResult).toHaveLength(2);
+      expect(googleResult.map((r) => r.url)).toContain(
+        "https://google.com/search",
+      );
+      expect(googleResult.map((r) => r.url)).toContain(
+        "https://maps.google.com",
+      );
+
+      // Test partial domain search
+      const yahoResult = await search("site:yahoo");
+      expect(yahoResult).toHaveLength(1);
+      expect(yahoResult[0]?.url).toBe("https://yahoo.com");
+    });
+
+    it("should combine site: search with regular search terms", async () => {
+      // Create test bookmarks
+      const historyItems: HistoryItem[] = [
+        {
+          id: "1",
+          url: "https://google.com/search",
+          title: "Google Search Engine",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 10, 30, 0).getTime(),
+          domain: "google.com",
+        },
+        {
+          id: "2",
+          url: "https://google.com/maps",
+          title: "Google Maps",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 11, 0, 0).getTime(),
+          domain: "google.com",
+        },
+        {
+          id: "3",
+          url: "https://yahoo.com",
+          title: "Yahoo Search Engine",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 12, 0, 0).getTime(),
+          domain: "yahoo.com",
+        },
+      ];
+      await insertHistories(...historyItems);
+
+      // Search for "search" within google.com domain
+      const result = await search("site:google.com search");
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        url: "https://google.com/search",
+        title: "Google Search Engine",
+      });
+    });
+
+    it("should handle multiple site: terms", async () => {
+      const historyItems: HistoryItem[] = [
+        {
+          id: "1",
+          url: "https://google.com",
+          title: "Google",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 10, 30, 0).getTime(),
+          domain: "google.com",
+        },
+        {
+          id: "2",
+          url: "https://search.yahoo.com",
+          title: "Yahoo Search",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 11, 0, 0).getTime(),
+          domain: "search.yahoo.com",
+        },
+        {
+          id: "3",
+          url: "https://example.com",
+          title: "Example",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 12, 0, 0).getTime(),
+          domain: "example.com",
+        },
+      ];
+      await insertHistories(...historyItems);
+
+      // Multiple site: terms should match domains containing both terms
+      const result = await search("site:search site:yahoo");
+      expect(result).toHaveLength(1);
+      expect(result[0]?.url).toBe("https://search.yahoo.com");
+    });
+
+    it("should return empty array when site: matches no domains", async () => {
+      const historyItems: HistoryItem[] = [
+        {
+          id: "1",
+          url: "https://google.com",
+          title: "Google",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 10, 30, 0).getTime(),
+          domain: "google.com",
+        },
+      ];
+      await insertHistories(...historyItems);
+
+      const result = await search("site:nonexistent.com");
+      expect(result).toEqual([]);
+    });
+
+    it("should handle invalid URLs gracefully in site: search", async () => {
+      // Add a bookmark with an invalid URL (this shouldn't normally happen, but test defensive coding)
+      const mockBookmark = {
+        id: "invalid",
+        title: "Invalid URL Bookmark",
+        url: "not-a-valid-url",
+        parentId: "some-parent",
+      };
+      mockBookmarkUtils.addMockBookmark(mockBookmark);
+
+      // This should not throw an error and should simply not match
+      const result = await search("site:example.com");
+      expect(result).toEqual([]);
+    });
   });
 
   describe("getRecentHistories", () => {

--- a/src/lib/storage.spec.ts
+++ b/src/lib/storage.spec.ts
@@ -447,6 +447,22 @@ describe("storage", () => {
           lastVisitTime: new Date(2024, 0, 15, 12, 0, 0).getTime(),
           domain: "yahoo.com",
         },
+        {
+          id: "4",
+          url: "https://other.com/google.com",
+          title: "other Homepage (Google Link)",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 12, 0, 0).getTime(),
+          domain: "other.com",
+        },
+        {
+          id: "5",
+          url: "https://other.com",
+          title: "other Homepage (google.com)",
+          visitCount: 1,
+          lastVisitTime: new Date(2024, 0, 15, 12, 0, 0).getTime(),
+          domain: "other.com",
+        },
       ];
       await insertHistories(...historyItems);
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,6 +10,7 @@ import {
   serializeHistoryItemToBookmark,
 } from "./bookmark-serializer";
 import { dateToFolderNames, getDateArray } from "./date";
+import { parseSearchQuery } from "./query";
 import { HistoryItem } from "../types/HistoryItem";
 
 export const ROOT_FOLDER_NAME = "Eternal History";
@@ -246,36 +247,6 @@ export async function search(query: string): Promise<HistoryItem[]> {
       }
     });
   });
-}
-
-/**
- * 検索クエリを解析して各タームの種類を識別します。
- */
-function parseSearchQuery(query: string): Array<{
-  term: string;
-  type: "text" | "site";
-}> {
-  const terms = query
-    .trim()
-    .split(/\s+/)
-    .filter((term) => term.length > 0);
-
-  const parsedTerms = terms
-    .map((term) => {
-      if (term.toLowerCase().startsWith("site:")) {
-        const siteTerm = term.slice(5).toLowerCase();
-        if (siteTerm.length > 0) {
-          return { term: siteTerm, type: "site" } as const;
-        }
-        return null;
-      }
-      return { term: term.toLowerCase(), type: "text" } as const;
-    })
-    .filter((item) => item !== null)
-    // テキスト検索語を長い順にソート (最も長い単語でまず検索するため)
-    .sort((a, b) => b.term.length - a.term.length);
-
-  return parsedTerms;
 }
 
 async function searchHistoriesByQuery(query: string): Promise<HistoryItem[]> {


### PR DESCRIPTION
## Summary

- Added `site:example.com` domain search syntax with partial matching support
- Optimized search performance by using Chrome API instead of full scan  
- Maintains compatibility with existing AND search functionality
- Comprehensive test coverage including edge cases

## Features

**Site Search Syntax**
- `site:google.com` - Search specific domain
- `site:example.com search` - Combine domain + keyword filtering
- Partial domain matching (e.g., `site:google` matches `maps.google.com`)

**Performance Improvements** 
- Uses Chrome bookmarks API search with first term for efficiency
- Eliminates full history scan for site-only queries
- Scales well with large history datasets (thousands of entries)

**Technical Implementation**
- Unified parser structure: `{ term: string, type: 'text' | 'site' }[]`
- Hostname-based filtering for site: terms
- Full-text filtering for regular search terms
- Maintains existing sort behavior (longest terms first)

## Test Plan

✅ All existing tests pass (backward compatibility)
✅ Site syntax parsing and filtering
✅ Domain + keyword combination search  
✅ Multiple site: terms support
✅ Edge cases: invalid URLs, no matches
✅ Hostname-only matching (excludes URL paths/titles containing domains)

🤖 Generated with [Claude Code](https://claude.ai/code)