### PR TITLE
feat: add build:dev script and workflow improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,14 @@ jobs:
       - name: 🐢 Run Test
         run: npm run test
 
-      - name: Bump version
+      - name: 💪 Bump version
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           HUSKY=0 npm version patch
           git push origin main --follow-tags
 
-      - name: Build extension
+      - name: 🔧 Build extension
         run: npm run build
 
       - name: Set version from package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "prettier": "^3.4.2",
         "react-docgen-typescript": "^2.4.0",
         "storybook": "^9.0.9",
-        "tsx": "^4.19.3",
         "typescript": "5.8.3",
         "typescript-eslint": "^8.31.0",
         "vite": "^6.2.0",
@@ -4131,6 +4130,8 @@
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
       "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -6383,6 +6384,8 @@
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -7326,6 +7329,8 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc -b && vite build --emptyOutDir",
+    "build:dev": "npm run build && node scripts/update-manifest-name-for-dev.ts",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit",
     "prepare": "husky",
@@ -58,7 +59,6 @@
     "prettier": "^3.4.2",
     "react-docgen-typescript": "^2.4.0",
     "storybook": "^9.0.9",
-    "tsx": "^4.19.3",
     "typescript": "5.8.3",
     "typescript-eslint": "^8.31.0",
     "vite": "^6.2.0",

--- a/scripts/update-manifest-name-for-dev.ts
+++ b/scripts/update-manifest-name-for-dev.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+
+const MANIFEST_PATH = "./dist/manifest.json";
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf-8"));
+fs.writeFileSync(
+  MANIFEST_PATH,
+  JSON.stringify({ ...manifest, name: `${manifest.name} (dev)` }, null, 2) +
+    "\n",
+);
+
+console.log(
+  `Updated manifest.json name to ${manifest.name} (dev) for development build`,
+);
+console.log("Development build completed successfully!");


### PR DESCRIPTION
## Summary

- Added `npm run build:dev` script for development builds with clear Chrome extension identification
- Enhanced GitHub Actions workflow with improved readability
- Cleaned up dependencies by removing unused tsx package

## New Features

**Development Build Script**
- `npm run build:dev` creates builds with "(dev)" suffix in extension name
- Easy distinction between production and development builds in Chrome extensions page
- No source file modifications during build process

**Workflow Improvements**
- Added emojis to GitHub Actions steps for better readability
- 💪 Bump version, 🔧 Build extension for clearer pipeline visualization

## Technical Implementation

**Build Process**
- Uses standard `npm run build` followed by manifest name modification
- Only modifies `dist/manifest.json`, leaves source files untouched
- Simple Node.js script without additional build tool dependencies

**Dependency Cleanup**
- Removed unused `tsx` dependency
- Leverages Node.js built-in TypeScript support for scripts
- Reduced package size and complexity

## Test Plan

✅ Development build creates extension with "(dev)" name
✅ Production build remains unchanged
✅ All existing functionality preserved
✅ TypeScript compilation and linting pass
✅ GitHub Actions workflow displays improved readability

🤖 Generated with [Claude Code](https://claude.ai/code)