### PR TITLE
feat: add developer credit footer to options page

### DIFF
--- a/src/components/settings/OptionsPage/index.tsx
+++ b/src/components/settings/OptionsPage/index.tsx
@@ -41,6 +41,21 @@ export const OptionsPage: FC<OptionsPageProps> = ({
       </h1>
 
       <OptionsForm initialSettings={initialSettings} {...props} />
+
+      <footer className='mt-auto pt-8 text-center text-sm text-gray-400'>
+        Eternal History by{" "}
+        <a
+          href='https://manaten.net'
+          target='_blank'
+          rel='noopener noreferrer'
+          className='
+            text-emerald-400 underline transition-colors
+            hover:text-white
+          '
+        >
+          manaten
+        </a>
+      </footer>
     </main>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -227,24 +227,26 @@
   accent-color: var(--color-theme-600);
 }
 
-body {
-  color: #1f2937;
-  font-size: 14px;
-  line-height: 1.5;
-  min-height: 100vh;
-  overflow-y: scroll;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-    "Cantarell", sans-serif;
-  background-image: var(--background-image, none);
-  background-size: 100vw 100vh;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@layer base {
+  body {
+    color: #1f2937;
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+    overflow-y: scroll;
+    font-family:
+      -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+      "Ubuntu", "Cantarell", sans-serif;
+    background-image: var(--background-image, none);
+    background-size: 100vw 100vh;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 
-a {
-  color: inherit;
-  text-decoration: none;
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
## Summary
- Add developer credit footer "Eternal History by manaten" to options page
- Move base styles into `@layer base` to fix CSS cascade issues with Tailwind utilities

## Changes
- Added footer component to OptionsPage with link to https://manaten.net
- Wrapped `body` and `a` reset styles in `@layer base` to ensure Tailwind utility classes (like `text-emerald-400`, `underline`) properly override base styles
- Link styled with emerald color matching the theme, with hover effect

## Technical Notes
The key fix was moving reset styles into `@layer base`. Previously, these styles were unlayered and had higher priority than Tailwind's `@layer utilities`, preventing utility classes from working correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)