### PR TITLE
chore: 検索パスに dev ビルド限定の計測ログを追加

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -12,6 +12,7 @@ import {
 import { HistoryItem } from "../types/HistoryItem";
 import { uniqBy } from "../util/array";
 import { dateToFolderNames, getDateArray } from "../util/date";
+import { perfReport, PerfReport } from "../util/perf";
 import { parseSearchQuery } from "../util/query";
 
 export interface SearchOptions {
@@ -96,16 +97,19 @@ async function getLastVisitTimeFromPath(
 
 async function convertBookmarkToHistoryItem(
   bookmark: chrome.bookmarks.BookmarkTreeNode,
+  report?: PerfReport,
 ): Promise<HistoryItem> {
   const item = deserializeBookmarkToHistoryItem(bookmark);
 
-  // If no precise timestamp from metadata, fall back to folder-based calculation
-  const lastVisitTime =
-    item.lastVisitTime || (await getLastVisitTimeFromPath(bookmark));
+  if (item.lastVisitTime) {
+    return item;
+  }
 
+  // If no precise timestamp from metadata, fall back to folder-based calculation
+  report?.count("pathFallback");
   return {
     ...item,
-    lastVisitTime,
+    lastVisitTime: await getLastVisitTimeFromPath(bookmark),
   };
 }
 
@@ -257,6 +261,8 @@ export async function search(
   query: string,
   options?: SearchOptions,
 ): Promise<HistoryItem[]> {
+  const report = perfReport(`search(${JSON.stringify(query)})`);
+
   if (!rootFolderId) {
     return [];
   }
@@ -270,55 +276,83 @@ export async function search(
   }
 
   // まず最初の非除外単語で全体から検索
-  const bookmarks = await searchHistoriesByQuery(nonExcludeTerms[0].term);
+  const bookmarks = await searchHistoriesByQuery(
+    nonExcludeTerms[0].term,
+    report,
+  );
 
   // フィルタリング
-  const filtered = bookmarks.filter((bookmark) => {
-    const searchText = `${bookmark.title} ${bookmark.url}`.toLowerCase();
+  const filtered = await report.span("filter", () =>
+    bookmarks.filter((bookmark) => {
+      const searchText = `${bookmark.title} ${bookmark.url}`.toLowerCase();
 
-    return parsedTerms.every((parsedTerm) => {
-      // 除外条件
-      if (parsedTerm.type === "exclude") {
-        return !searchText.includes(parsedTerm.term);
-      }
-
-      // site:条件は hostname に対してチェック
-      if (parsedTerm.type === "site") {
-        try {
-          const url = new URL(bookmark.url);
-          return url.hostname.includes(parsedTerm.term);
-        } catch {
-          return false;
+      return parsedTerms.every((parsedTerm) => {
+        // 除外条件
+        if (parsedTerm.type === "exclude") {
+          return !searchText.includes(parsedTerm.term);
         }
-      }
 
-      // text条件は title と url 全体に対してチェック
-      return searchText.includes(parsedTerm.term);
-    });
-  });
+        // site:条件は hostname に対してチェック
+        if (parsedTerm.type === "site") {
+          try {
+            const url = new URL(bookmark.url);
+            return url.hostname.includes(parsedTerm.term);
+          } catch {
+            return false;
+          }
+        }
+
+        // text条件は title と url 全体に対してチェック
+        return searchText.includes(parsedTerm.term);
+      });
+    }),
+  );
+  report.count("filtered", filtered.length);
 
   // グルーピング処理
-  return groupHistories(filtered, options);
+  const grouped = await report.span("group", () =>
+    groupHistories(filtered, options),
+  );
+  report.count("grouped", grouped.length);
+
+  report.log();
+  return grouped;
 }
 
-async function searchHistoriesByQuery(query: string): Promise<HistoryItem[]> {
+async function searchHistoriesByQuery(
+  query: string,
+  report: PerfReport,
+): Promise<HistoryItem[]> {
   if (!rootFolderId) {
     return [];
   }
 
-  const bookmarks = await chrome.bookmarks.search({ query });
-  return (
-    await pMap(bookmarks, async (bookmark) => {
-      if (
-        bookmark.url &&
-        rootFolderId &&
-        (await isUnderFolder(bookmark, rootFolderId))
-      ) {
-        return await convertBookmarkToHistoryItem(bookmark);
-      }
-      return null;
-    })
-  ).filter((item) => item !== null);
+  const bookmarks = await report.span("bookmarks.search", () =>
+    chrome.bookmarks.search({ query }),
+  );
+  report.count("hits", bookmarks.length);
+
+  const underRoot = (
+    await report.span("isUnderFolder", () =>
+      pMap(bookmarks, async (bookmark) => {
+        if (
+          bookmark.url &&
+          rootFolderId &&
+          (await isUnderFolder(bookmark, rootFolderId))
+        ) {
+          return bookmark;
+        }
+        return null;
+      }),
+    )
+  ).filter((b) => b !== null);
+  report.count("underRoot", underRoot.length);
+
+  return report.span("convert", () =>
+    pMap(underRoot, (bookmark) =>
+      convertBookmarkToHistoryItem(bookmark, report),
+    ),
+  );
 }
 
 /**
@@ -395,13 +429,14 @@ export async function deleteHistoryItem(
 export async function getRecentHistories(
   days: number = 3,
 ): Promise<HistoryItem[]> {
+  const report = perfReport(`getRecentHistories(${days})`);
+
   if (!rootFolderId) {
     return [];
   }
 
-  const dayBookmarksArrays = await pMap(
-    getDateArray(new Date(), -days),
-    async (targetDate) => {
+  const dayBookmarksArrays = await report.span("collectDays", () =>
+    pMap(getDateArray(new Date(), -days), async (targetDate) => {
       const { year, month, day } = dateToFolderNames(targetDate);
 
       try {
@@ -410,16 +445,23 @@ export async function getRecentHistories(
         const dayFolderId = await getOrCreateFolder(monthFolderId, day);
 
         const bookmarks = await getAllBookmarksInFolder(dayFolderId);
-        return await pMap(bookmarks, convertBookmarkToHistoryItem);
+        return await pMap(bookmarks, (b) =>
+          convertBookmarkToHistoryItem(b, report),
+        );
       } catch (error) {
         console.log(`No bookmarks found for ${year}/${month}/${day}`, error);
         return [];
       }
-    },
+    }),
   );
 
   const historyBookmarks = dayBookmarksArrays.flat();
-  return [...historyBookmarks].sort(
-    (a, b) => b.lastVisitTime - a.lastVisitTime,
+  report.count("items", historyBookmarks.length);
+
+  const sorted = await report.span("sort", () =>
+    [...historyBookmarks].sort((a, b) => b.lastVisitTime - a.lastVisitTime),
   );
+
+  report.log();
+  return sorted;
 }

--- a/src/util/perf.ts
+++ b/src/util/perf.ts
@@ -1,0 +1,57 @@
+const enabled = import.meta.env.DEV;
+
+export interface PerfReport {
+  span<T>(name: string, fn: () => Promise<T> | T): Promise<T>;
+  count(name: string, n?: number): void;
+  log(extra?: Record<string, unknown>): void;
+}
+
+const noop: PerfReport = {
+  async span(_name, fn) {
+    return fn();
+  },
+  count() {},
+  log() {},
+};
+
+/**
+ * dev ビルド時のみ計測を有効化する簡易プロファイラ。
+ * span で囲んだ処理の所要時間と count で記録した件数を蓄積し、
+ * log() で 1 行のサマリとして出力します。
+ */
+export function perfReport(label: string): PerfReport {
+  if (!enabled) {
+    return noop;
+  }
+
+  const start = performance.now();
+  const spans: Record<string, number> = {};
+  const counts: Record<string, number> = {};
+
+  return {
+    async span(name, fn) {
+      const s = performance.now();
+      try {
+        return await fn();
+      } finally {
+        // eslint-disable-next-line functional/immutable-data
+        spans[name] = (spans[name] ?? 0) + (performance.now() - s);
+      }
+    },
+    count(name, n = 1) {
+      // eslint-disable-next-line functional/immutable-data
+      counts[name] = (counts[name] ?? 0) + n;
+    },
+    log(extra) {
+      const total = performance.now() - start;
+      const breakdown = Object.fromEntries(
+        Object.entries(spans).map(([k, v]) => [k, +v.toFixed(1)]),
+      );
+      console.log(`[perf] ${label} total=${total.toFixed(1)}ms`, {
+        breakdown,
+        counts,
+        ...(extra ?? {}),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## 背景

利用開始から 1 年ほど経過し、`github` のような頻出語での検索に 10 秒近くかかるようになった。
ストレージを SQLite (OPFS + wa-sqlite) へ移行する案も検討したが、

- 既存ユーザー (社内利用あり) への移行リスク
- ブックマーク経由の端末間同期という副次効果が失われること
- 現行コードの再帰的な親フォルダ走査 (`isUnderFolder`) が支配的である**仮説**

から、まずは現行ストレージのまま最適化する方向で検討したい。
そのために**実測**でボトルネックを特定する必要がある。

## 変更内容

- `src/util/perf.ts` を追加
  - `import.meta.env.DEV` が真のときのみ計測する軽量プロファイラ
  - prod ビルドでは no-op (`console.log` も出さない)
  - `span(name, fn)` で時間、`count(name)` で件数を蓄積、`log()` で 1 行サマリを出力
- `src/lib/storage.ts` の `search()` と `getRecentHistories()` に計測を仕込む
  - `search`: `bookmarks.search` / `isUnderFolder` / `convert` / `filter` / `group` の各フェーズ
  - 件数: `hits` (Chrome 全体のヒット数) / `underRoot` (Eternal History 配下のみ) / `pathFallback` (メタデータに `t` が無くフォルダパスから時刻復元したケース) / `filtered` / `grouped`
- 既存の `searchHistoriesByQuery` / `convertBookmarkToHistoryItem` のシグネチャに `PerfReport` を受け取れるよう改修 (機能変更なし)

## 出力例

```
[perf] search("github") total=8423.4ms {
  breakdown: { 'bookmarks.search': 120.3, isUnderFolder: 7800.1, convert: 480.2, filter: 15.4, group: 8.1 },
  counts: { hits: 2341, underRoot: 2330, pathFallback: 0, filtered: 2100, grouped: 87 }
}
```

## 動作確認

- [x] `npm run typecheck`
- [x] `npm test` (114 件 pass)
- [x] `npm run lint`
- [ ] `npm run dev` で実機ロードし、頻出語で検索してフェーズ別の所要時間を採取する (次のステップ)

## このあとの予定

採取結果次第で:

- 仮説通り `isUnderFolder` が支配的なら、フォルダ ID を起動時に `Set` にキャッシュして `O(1)` ルックアップ化する案へ
- 違うフェーズが支配的なら、そこを掘り下げて打ち手を再検討


---
_Generated by [Claude Code](https://claude.ai/code/session_016kT25GakpRWLeEFbMkBLiK)_