### PR TITLE
ci: PRタイトルからリリースノートを自動生成

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release Extension
 
 on:
   workflow_dispatch:
-    inputs:
-      release_body:
-        description: "Release body (changelog)"
-        required: true
-        type: string
 
 jobs:
   build-and-release:
@@ -65,6 +60,6 @@ jobs:
         with:
           files: output/eternal-history-v${{ env.VERSION }}.zip
           tag_name: v${{ env.VERSION }}
-          body: ${{ github.event.inputs.release_body }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- リリースワークフローの `workflow_dispatch` `release_body` 入力を削除し、手動入力を不要に
- `softprops/action-gh-release` に `generate_release_notes: true` を指定し、GitHub Releases API が前回タグから今回タグまでにマージされた PR タイトルからリリースノートを自動生成

## Test plan

- [ ] `Actions` から `Release Extension` を手動実行し、入力フィールドが消えていることを確認
- [ ] リリースが作成され、リリースノートに前回タグ以降の PR タイトルが自動で記載されていることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGcMBEZDfb8fudjSA1BQBR)_