### PR TITLE
ci: リリース時にバージョンアップ種別を選択可能に

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,16 @@ name: Release Extension
 
 on:
   workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type"
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   build-and-release:
@@ -39,7 +49,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          HUSKY=0 npm version patch
+          HUSKY=0 npm version ${{ github.event.inputs.version_type }}
           git push origin main --follow-tags
 
       - name: 🔧 Build extension


### PR DESCRIPTION
## Summary

- `Release Extension` ワークフローの `workflow_dispatch` に `version_type` (choice: `patch` / `minor` / `major`、デフォルト `patch`) を追加
- `npm version` の引数に選択値を渡し、バージョンアップ種別を実行時に切り替え可能に

## Test plan

- [ ] `Actions` から `Release Extension` を手動実行し、`Version bump type` のドロップダウンが表示されることを確認
- [ ] `patch` を選んで実行し、従来通りパッチバージョンが上がることを確認
- [ ] `minor` / `major` を選んで実行し、対応する桁が上がることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGcMBEZDfb8fudjSA1BQBR)_