### PR TITLE
ci: バージョンアップの push を atomic 化してタグだけ先行を防ぐ

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           HUSKY=0 npm version ${{ github.event.inputs.version_type }}
-          git push origin main --follow-tags
+          git push --atomic origin main --follow-tags
 
       - name: 🔧 Build extension
         run: npm run build


### PR DESCRIPTION
## Summary

- `Bump version` ステップの `git push` に `--atomic` を追加
- 元実装は `git push origin main --follow-tags` だったため、main への push がリポジトリルール違反等で拒否されてもタグだけ先行 push されてしまう問題があった (実際に v1.0.17 タグが孤立コミットに残る事故が発生)
- `--atomic` により、いずれかの ref 更新が失敗した場合は全 ref がまとめて失敗するようになり、タグだけ残る状態を防ぐ

## Test plan

- [ ] 次回リリース時、`Bump version` が成功すれば main コミット + タグが両方リモートに反映されることを確認
- [ ] (確認できれば) push が失敗するケースで、タグも push されないことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGcMBEZDfb8fudjSA1BQBR)_